### PR TITLE
GAAD 2022 challenge: Move getting started info to the start

### DIFF
--- a/global-accessibility-awareness-day/2022.md
+++ b/global-accessibility-awareness-day/2022.md
@@ -8,20 +8,18 @@ In the UK around [2 million people live with sight loss][sight-loss]. There are 
 
 [sight-loss]: https://www.rnib.org.uk/professionals/knowledge-and-research-hub/key-information-and-statistics
 
-On Global Accessibility Awareness Day, we want to ask you to spend half an hour getting to know a screen reader such as [VoiceOver](https://www.apple.com/accessibility/vision/). If you are already familiar with using a screen reader, we encourage you to try firing it up and browsing one of our products. It could be theguardian.com, one of our apps or a product your team maintains.
+On Global Accessibility Awareness Day, we want to ask you to spend half an hour getting to know a screen reader such as [VoiceOver](https://www.apple.com/accessibility/vision/). For Mac users, the VoiceOver screen reader is built in to your laptop. WebAIM provides a useful guide to [testing accessibility with VoiceOver](https://webaim.org/articles/voiceover/).
+
+If you are already familiar with using a screen reader, we encourage you to try firing it up and browsing one of our products. It could be theguardian.com, one of our apps or a product your team maintains.
 
 If you'd like to give yourself a challenge, why not try our **Screen Reader Speedrun**:
 
 - on your laptop, open [theguardian.com](https://www.theguardian.com) in the Safari web browser.
 - set a stopwatch - use your phone, or [search Google for "stopwatch"](https://www.google.com/search?q=stopwatch) to bring one up in another tab
-- fire up the screen reader software on your device (for instructions on how to do this, see "Getting started" below)
+- fire up the screen reader software on your device
 - see how fast you can navigate the most viewed article on the website today. The "Most Viewed" component usually appears toward the bottom of the page.
 
 Once you have completed this, you can share your time in the [P&E/Accessibility space](https://mail.google.com/chat/u/0/?zx=tg6rca8mr6kx#chat/space/AAAAoMQI1jM)
-
-### Getting started
-
-For Mac users, the VoiceOver screen reader is built in to your laptop. WebAIM provides a useful guide to [testing accessibility with VoiceOver](https://webaim.org/articles/voiceover/).
 
 ### What do we want you to take away from this?
 


### PR DESCRIPTION
## What does this change?

Move the link to the WebAIM guide to VoiceOver testing to the beginning of the document. It is currently buried in a "getting started" section further down the document, and may not be obvious.

